### PR TITLE
Patch delay in tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ celery==4.3.0
 cwltool==2.0.20200122124526
 schema-salad==5.0.20200122085940
 psycopg2-binary==2.8.4
+mock==4.0.2


### PR DESCRIPTION
We don't run celery workers in travis, so submitting celery jobs wouldn't provide us any value since they wouldn't be executed, and than adding RabbitMQ would add additional complexity which we don't need.