### PR TITLE
Shutdown check_status_of_command_line_jobs

### DIFF
--- a/toil_orchestrator/celery.py
+++ b/toil_orchestrator/celery.py
@@ -38,9 +38,9 @@ app.conf.beat_schedule = {
         "schedule": 60.0,
         "options": {"queue": settings.RIDGEBACK_DEFAULT_QUEUE}
     },
-    "check_status_of_command_line_jobs": {
-        "task": "toil_orchestrator.tasks.check_status_of_command_line_jobs",
-        "schedule": 10.0,
-        "options": {"queue": settings.RIDGEBACK_DEFAULT_QUEUE}
-    }
+    # "check_status_of_command_line_jobs": {
+    #     "task": "toil_orchestrator.tasks.check_status_of_command_line_jobs",
+    #     "schedule": 10.0,
+    #     "options": {"queue": settings.RIDGEBACK_DEFAULT_QUEUE}
+    # }
 }


### PR DESCRIPTION
Shutdown check_status_of_command_line_jobs until we find out why it causes infinite loop