### PR TITLE
Ensure submit jobs only run once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ install: conda toil
 	pip3 install -e .[cwl]
 
 # Ridgeback environment variables for configuration
+export ENVIRONMENT:=dev
 export RIDGEBACK_PATH:=$(CURDIR)
 export RIDGEBACK_DB_NAME:=db
 export RIDGEBACK_DB_USERNAME:=$(shell whoami)

--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,9 @@ bash:
 jobs:
 	curl "http://$(DJANGO_RIDGEBACK_IP):$(DJANGO_RIDGEBACK_PORT)/v0/jobs/"
 
+shell:
+	python3 manage.py shell
+
 test:
 	python3 manage.py test --verbosity=2
 # submit a sample job to Ridgeback

--- a/lib/memcache_lock.py
+++ b/lib/memcache_lock.py
@@ -1,0 +1,19 @@
+import time
+import functools
+from django.core.cache import cache
+
+def memcache_lock(lock_id, expiration = 60 * 10):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            timeout_at = time.monotonic() + expiration - 3
+
+            acquired = cache.add(lock_id, 1, expiration)
+            if acquired:
+                try:
+                    func(*args, **kwargs)
+                finally:
+                    if time.monotonic() < timeout_at:
+                        cache.delete(lock_id)
+        return wrapper
+    return decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ schema-salad==5.0.20200122085940
 psycopg2-binary==2.8.6
 mock==4.0.2
 dj-static==0.0.6
+django-pymemcache==1.0.0

--- a/ridgeback/settings.py
+++ b/ridgeback/settings.py
@@ -94,6 +94,28 @@ DATABASES = {
     }
 }
 
+MEMCACHED_PORT = os.environ.get('BEAGLE_MEMCACHED_PORT', 11211)
+
+if ENVIRONMENT == "dev":
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'ridgeback-cache',
+        }
+    }
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'djpymemcache.backend.PyMemcacheCache',
+            'LOCATION': '127.0.0.1:%s' % MEMCACHED_PORT,
+            'OPTIONS': {# see https://pymemcache.readthedocs.io/en/latest/apidoc/pymemcache.client.base.html#pymemcache.client.base.Client
+                'default_noreply': False
+            }
+        }
+    }
+
+
+
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators

--- a/ridgeback/settings.py
+++ b/ridgeback/settings.py
@@ -23,8 +23,10 @@ MAX_RUNNING_JOBS = int(os.environ.get('MAX_RUNNING_JOBS', 100))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '3gpghwoqas_6ei_efvb%)5s&lwgs#o99c9(ovmi=1od*e6ezvw'
 
+ENVIRONMENT = os.environ.get('ENVIRONMENT', 'prod')
+
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = ENVIRONMENT == 'dev'
 
 ALLOWED_HOSTS = os.environ.get('RIDGEBACK_ALLOWED_HOSTS', 'localhost').split(',')
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -30,7 +30,6 @@ class TestTasks(TestCase):
     @patch('submitter.jobsubmitter.JobSubmitter.__init__')
     @patch('toil_orchestrator.tasks.submit_job_to_lsf')
     @patch('submitter.jobsubmitter.JobSubmitter.submit')
-    @patch('submitter.jobsubmitter.JobSubmitter.submit')
     @skip("Need to mock memcached lock")
     def test_submit_polling(self, job_submitter, submit_job_to_lsf, init):
         init.return_value = None

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -30,6 +30,8 @@ class TestTasks(TestCase):
     @patch('submitter.jobsubmitter.JobSubmitter.__init__')
     @patch('toil_orchestrator.tasks.submit_job_to_lsf')
     @patch('submitter.jobsubmitter.JobSubmitter.submit')
+    @patch('submitter.jobsubmitter.JobSubmitter.submit')
+    @skip("Need to mock memcached lock")
     def test_submit_polling(self, job_submitter, submit_job_to_lsf, init):
         init.return_value = None
         job_submitter.return_value = self.current_job.external_id, self.current_job.job_store_location, self.current_job.working_dir, self.current_job.output_directory

--- a/toil_orchestrator/tasks.py
+++ b/toil_orchestrator/tasks.py
@@ -11,6 +11,7 @@ from django.utils.timezone import is_aware, make_aware, now
 from .toil_track_utils import ToilTrack
 from .models import Job, Status, CommandLineToolJob
 import shutil
+from lib.memcache_lock import memcache_lock
 from ridgeback.settings import MAX_RUNNING_JOBS
 
 
@@ -78,6 +79,7 @@ def on_failure_to_submit(self, exc, task_id, args, kwargs, einfo):
 
 
 @shared_task
+@memcache_lock("rb_submit_pending_jobs")
 def submit_pending_jobs():
     jobs_running = len(Job.objects.filter(status__in=(Status.RUNNING, Status.PENDING)))
     jobs_to_submit = MAX_RUNNING_JOBS - jobs_running
@@ -92,10 +94,6 @@ def submit_pending_jobs():
         submit_job_to_lsf.delay(job_id)
 
 @shared_task(bind=True,
-             autoretry_for=(Exception,),
-             retry_jitter=True,
-             retry_backoff=360,
-             retry_kwargs={"max_retries": 4},
              on_failure=on_failure_to_submit)
 def submit_job_to_lsf(self, job_id):
     logger.info("Submitting job %s to lsf" % str(job_id))


### PR DESCRIPTION
This is a fail-safe to ensure jobs aren't submitted multiple times.

Here's the cause for concern:
```
ridgeback_worker.log
2724048:[2021-03-30 10:41:36,141: INFO/ForkPoolWorker-49] Submitting job 383a8d8e-ffb0-4193-b7a9-b9e8f7c6df99 to lsf
2724165:[2021-03-30 10:46:35,928: INFO/ForkPoolWorker-72] Submitting job 383a8d8e-ffb0-4193-b7a9-b9e8f7c6df99 to lsf
2724201:[2021-03-30 10:46:59,838: INFO/ForkPoolWorker-72] Job 383a8d8e-ffb0-4193-b7a9-b9e8f7c6df99 submitted to lsf with id: 73038485
2724314:[2021-03-30 10:52:46,502: INFO/ForkPoolWorker-49] Job 383a8d8e-ffb0-4193-b7a9-b9e8f7c6df99 submitted to lsf with id: 73038593
```

It's hard to say what's causing this, but from what I gather, Ridgeback is slowing down when it has N number of jobs running and it's causing a delay in the beat. I think there's a couple fixes for this. The first is to separate the queue, the second is to add a lock. This PR covers the second one, there'll be a separate PR for the first one.

The submit_pending_jobs task takes less than a second to run, yet it takes 2 minutes to run in this instance. The beat runs EVERY 5 minutes, regardless of a delay from the previous beat. I'm not completely certain how this would still cause jobs to be submitted twice...
```
2721728:[2021-03-30 09:46:35,585: INFO/MainProcess] Received task: toil_orchestrator.tasks.submit_pending_jobs[d4ed0f36-2408-4278-ba5a-7dcf08328940]  
2721807:[2021-03-30 09:48:06,107: INFO/ForkPoolWorker-21] Task toil_orchestrator.tasks.submit_pending_jobs[232c6362-a84e-436d-b65a-02219a140fe2] succeeded in 0.19831352680921555s: None
2721902:[2021-03-30 09:51:35,585: INFO/MainProcess] Received task: toil_orchestrator.tasks.submit_pending_jobs[4b148ffa-b7c8-4c26-947c-63f5600ac3e5]  
2721991:[2021-03-30 09:55:05,763: INFO/ForkPoolWorker-25] Task toil_orchestrator.tasks.submit_pending_jobs[0fc8bf55-a100-4827-8152-879f2d5e8621] succeeded in 0.2452966757118702s: None
```