### PR TITLE
Enforce explicit separation of tool and leader bsub configuration

### DIFF
--- a/batch_systems/lsf_client/lsf_client.py
+++ b/batch_systems/lsf_client/lsf_client.py
@@ -26,19 +26,21 @@ class LSFClient():
         '''
         self.logger = logging.getLogger('LSF_client')
 
-    def submit(self, command, job_args, stdout):
+    def submit(self, command, job_args, tool_args, stdout):
         '''
         Submit command to LSF and store log in stdout
 
         Args:
             command (str): command to submit
             stdout (str): log file path
+            job_args (list): Additional options for leader bsub
+            tool_args (list): Additional options for tool bsub
 
         Returns:
             int: lsf job id
         '''
         bsub_command = ['bsub', '-sla', settings.LSF_SLA, '-oo', stdout] + job_args
-        toil_lsf_args = '-sla %s %s' % (settings.LSF_SLA, " ".join(job_args))
+        toil_lsf_args = '-sla %s %s' % (settings.LSF_SLA, " ".join(tool_args))
 
         bsub_command.extend(command)
         current_env = os.environ

--- a/submitter/jobsubmitter.py
+++ b/submitter/jobsubmitter.py
@@ -75,8 +75,9 @@ class JobSubmitter(object):
         self._prepare_directories()
         command_line = self._command_line()
         job_args = self._job_args()
+        tool_args = self._tool_args()
         log_path = os.path.join(self.job_work_dir, 'lsf.log')
-        external_id = self.lsf_client.submit(command_line, job_args, log_path)
+        external_id = self.lsf_client.submit(command_line, job_args, tool_args, log_path)
         return external_id, self.job_store_dir, self.job_work_dir, self.job_outputs_dir
 
     def status(self, external_id):
@@ -127,6 +128,10 @@ class JobSubmitter(object):
     def _job_args(self):
         args = self._walltime()
         args.extend(self._memlimit())
+        return args
+
+    def _tool_args(self):
+        args = self._walltime()
         return args
 
     def _walltime(self):


### PR DESCRIPTION
- Toil internally sets the memory of command line jobs, so setting memory in TOIL_LSF_ARGS causes a conflict.