### PR TITLE
Add timeout to submit_pending_jobs

### DIFF
--- a/container/celery_services.def
+++ b/container/celery_services.def
@@ -86,14 +86,16 @@ Includecmd: no
     --workdir ${RIDGEBACK_PATH} \
     -Q ${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE} \
     -f ${CELERY_LOG_PATH}/${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE}.log \
-    --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE}.pid &
+    --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE}.pid \
+    -n ${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE} &
 
     nohup celery -A orchestrator worker \
     -l info \
     --workdir ${RIDGEBACK_PATH} \
     -Q ${RIDGEBACK_ACTION_QUEUE} \
     -f ${CELERY_LOG_PATH}/${RIDGEBACK_ACTION_QUEUE}.log \
-    --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_ACTION_QUEUE}.pid &
+    --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_ACTION_QUEUE}.pid \
+    -n ${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_ACTION_QUEUE} &
 
     nohup celery -A orchestrator worker \
     -l info \
@@ -101,7 +103,8 @@ Includecmd: no
     -Q ${RIDGEBACK_CHECK_STATUS_QUEUE} \
     -f ${CELERY_LOG_PATH}/${RIDGEBACK_CHECK_STATUS_QUEUE}.log \
     --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_CHECK_STATUS_QUEUE}.pid \
-    --concurrency=1 &
+    --concurrency=1 \
+    -n ${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_CHECK_STATUS_QUEUE} &
 
     nohup celery -A orchestrator worker \
     -l info \
@@ -109,7 +112,8 @@ Includecmd: no
     -Q ${RIDGEBACK_SUBMIT_JOB_QUEUE} \
     -f ${CELERY_LOG_PATH}/${RIDGEBACK_SUBMIT_JOB_QUEUE}.log \
     --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_SUBMIT_JOB_QUEUE}.pid \
-    --concurrency=1 &
+    --concurrency=1 \
+    -n ${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_SUBMIT_JOB_QUEUE} &
 
     nohup celery -A orchestrator worker \
     -l info \
@@ -117,7 +121,8 @@ Includecmd: no
     -Q ${RIDGEBACK_CLEANUP_QUEUE} \
     -f ${CELERY_LOG_PATH}/${RIDGEBACK_CLEANUP_QUEUE}.log \
     --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_CLEANUP_QUEUE}.pid \
-    --concurrency=2 &
+    --concurrency=2 \
+    -n ${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_CLEANUP_QUEUE} &
 
 %post
     export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Occasionally duplicate jobs are being created which should be impossible based on the current configuration. I get the impression that UPDATE is somehow stalling and am looking into adding ways to observe this in Postgres. Until this, this may be enough to fix the issue. `submit_pending_jobs` should not complete if it takes longer than a few seconds to run.
<img width="1762" alt="Screen Shot 2021-04-15 at 12 26 32" src="https://user-images.githubusercontent.com/17934/114921221-4f21d680-9df8-11eb-807e-b54813ff32d1.png">
