### PR TITLE
Too many workers git cloning bogs down the system

### DIFF
--- a/container/celery_services.def
+++ b/container/celery_services.def
@@ -86,14 +86,18 @@ Includecmd: no
     --workdir ${RIDGEBACK_PATH} \
     -Q ${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE} \
     -f ${CELERY_LOG_PATH}/${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE}.log \
-    --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE}.pid &
+    --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE}.pid \
+    --concurrency=10 \
+    -n ${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_SUBMIT_JOB_LSF_QUEUE} &
 
     nohup celery -A orchestrator worker \
     -l info \
     --workdir ${RIDGEBACK_PATH} \
     -Q ${RIDGEBACK_ACTION_QUEUE} \
     -f ${CELERY_LOG_PATH}/${RIDGEBACK_ACTION_QUEUE}.log \
-    --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_ACTION_QUEUE}.pid &
+    --pidfile ${CELERY_PID_PATH}/${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_ACTION_QUEUE}.pid \
+    --concurrency=10 \
+    -n ${CELERY_EVENT_QUEUE_PREFIX}.${RIDGEBACK_ACTION_QUEUE} &
 
     nohup celery -A orchestrator worker \
     -l info \

--- a/orchestrator/tasks.py
+++ b/orchestrator/tasks.py
@@ -97,6 +97,7 @@ def submit_pending_jobs():
 
 
 @shared_task(bind=True,
+             soft_time_limit=60 * 3,
              on_failure=on_failure_to_submit)
 def submit_job_to_lsf(self, job_id):
     logger.info("Submitting job %s to lsf" % str(job_id))


### PR DESCRIPTION
I think a lot of the weird issues we've been seeing when we submit too many jobs have to do with contention for CPU -- which gets eaten up by all the heavy git clones we're doing...

This is a snapshot, but there can be up to 80 of these at a given time.
```
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
xxxxx  182425  5.2  0.0 454880 256944 ?       D    16:03   0:10 git clone git@github.com:mskcc/ACCESS-Pipeline --branch 2.0.0 --recurse-submodules
xxxxx  182829  4.9  0.0 445392 236160 ?       D    16:03   0:09 git clone git@github.com:mskcc/ACCESS-Pipeline --branch 2.0.0 --recurse-submodules
xxxxx  182815  4.5  0.0 445392 236160 ?       D    16:03   0:09 git clone git@github.com:mskcc/ACCESS-Pipeline --branch 2.0.0 --recurse-submodules
xxxxx  182828  4.2  0.0 443556 220976 ?       D    16:03   0:08 git clone git@github.com:mskcc/ACCESS-Pipeline --branch 2.0.0 --recurse-submodules
```