### PR TITLE
Avoid modifying ridgeback environment

### DIFF
--- a/batch_systems/lsf_client/lsf_client.py
+++ b/batch_systems/lsf_client/lsf_client.py
@@ -39,7 +39,7 @@ class LSFClient(object):
         bsub_command = ["bsub", "-sla", settings.LSF_SLA, "-oo", stdout] + job_args
 
         bsub_command.extend(command)
-        current_env = os.environ
+        current_env = os.environ.copy()
         for k, v in env.items():
             if v:
                 current_env[k] = v


### PR DESCRIPTION
Changed environment variables should only be applied to the app (in this case ACCESS) that changed them