### PR TITLE
access legacy conda env updates

### DIFF
--- a/ridgeback/settings.py
+++ b/ridgeback/settings.py
@@ -317,4 +317,6 @@ SKIP_THE_QUEUE_JOBS = ("ARGOS", "ACCESS_HEME", "ACCESS", "CMO-CH")
 
 # ACCESS LEGACY INFO
 ACCESS_LEGACY_APP = os.environ.get("ACCESS_LEGACY_APP", "access-pipeline")
-ACCESS_LEGACY_CONDA_ENV = os.environ.get("ACCESS_LEGACY_CONDA_ENV", "/usersoftware/core005/access/production/V1/micromamba/envs/ACCESS/bin")
+ACCESS_LEGACY_CONDA_ENV = os.environ.get(
+    "ACCESS_LEGACY_CONDA_ENV", "/usersoftware/core005/access/production/V1/micromamba/envs/ACCESS/bin"
+)

--- a/ridgeback/settings.py
+++ b/ridgeback/settings.py
@@ -317,3 +317,4 @@ SKIP_THE_QUEUE_JOBS = ("ARGOS", "ACCESS_HEME", "ACCESS", "CMO-CH")
 
 # ACCESS LEGACY INFO
 ACCESS_LEGACY_APP = os.environ.get("ACCESS_LEGACY_APP", "access-pipeline")
+ACCESS_LEGACY_CONDA_ENV = os.environ.get("ACCESS_LEGACY_CONDA_ENV", "/usersoftware/core005/access/production/V1/micromamba/envs/ACCESS/bin")

--- a/submitter/toil_submitter/toil_jobsubmitter.py
+++ b/submitter/toil_submitter/toil_jobsubmitter.py
@@ -245,7 +245,7 @@ class ToilJobSubmitter(JobSubmitter):
             """
             Start ACCESS-specific code
             """
-            path = "PATH={0}:{1}".format(settings.ACCESS_LEGACY_CONDA_ENV, os.environ.get("PATH"))
+            path = "env PATH={0}:{1}".format(settings.ACCESS_LEGACY_CONDA_ENV, os.environ.get("PATH"))
             command_line = [
                 path,
                 "toil-cwl-runner",

--- a/submitter/toil_submitter/toil_jobsubmitter.py
+++ b/submitter/toil_submitter/toil_jobsubmitter.py
@@ -245,8 +245,7 @@ class ToilJobSubmitter(JobSubmitter):
             """
             Start ACCESS-specific code
             """
-            access_path = "PATH=/usersoftware/core005/access/production/V1/micromamba/envs/ACCESS/bin:{}"
-            path = access_path.format(os.environ.get("PATH"))
+            path = "PATH={0}:{1}".format(settings.ACCESS_LEGACY_CONDA_ENV, os.environ.get("PATH"))
             command_line = [
                 path,
                 "toil-cwl-runner",


### PR DESCRIPTION
Adding updates after initial test on IRIS:
- [ ] specify access v1 conda environment location through settings variable
- [ ] add `env` to toil submission command so SLURM correctly interprets the conda environment path 